### PR TITLE
Add support for memory paging and virtual memory management

### DIFF
--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -202,6 +202,32 @@ extern "C" void kmain(struct stivale_struct *stivale_struct) {
     pci_scan_bus(my_pci_device_callback);
     tty_print("PCI bus scan done.\n", 0x4EC9B0);
 
+
+    tty_print("Testing paging...\n", 0xFFFFFF);
+    uint64_t* p = getPhysicalAddress((void*) 0x9000);
+    uint64_t* f = getPhysicalAddress((void*) 0xA000);
+
+    mapPage((void*)0x9000, (void*) 0x1000, 3);
+    mapPage((void*)0xA000, (void*) 0x1000, 3);
+
+    p = getPhysicalAddress((void*) 0x9001);
+    f = getPhysicalAddress((void*) 0xA000);
+
+    uint64_t* y = (uint64_t*) 0x9000;
+    *y = 0x114514;
+    print_hex(*y, 0xFFFFFF); // 若分页运行正常，应该输出*y的值
+    tty_print("\n", 0xFFFFFF);
+    uint64_t* z = (uint64_t*) 0xA000;
+    print_hex(*z, 0xFFFFFF);
+    tty_print("\n", 0xFFFFFF);
+
+
+    print_hex((uint64_t)p, 0xFFFFFF);
+    tty_print("\n", 0xFFFFFF);
+    print_hex((uint64_t)f, 0xFFFFFF);
+    tty_print("\n", 0xFFFFFF);
+    tty_print("\nPaging test done.\n", 0x4EC9B0);
+
     print("[System ready.]\n", blue);
 
     init_shell();

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -203,29 +203,46 @@ extern "C" void kmain(struct stivale_struct *stivale_struct) {
     tty_print("PCI bus scan done.\n", 0x4EC9B0);
 
 
-    tty_print("Testing paging...\n", 0xFFFFFF);
-    uint64_t* p = getPhysicalAddress((void*) 0x9000);
-    uint64_t* f = getPhysicalAddress((void*) 0xA000);
-
+    tty_print("\n-----Testing Paging-----\n", 0x569CD6);
+    // 映射虚拟地址到物理地址
     mapPage((void*)0x9000, (void*) 0x1000, 3);
     mapPage((void*)0xA000, (void*) 0x1000, 3);
 
-    p = getPhysicalAddress((void*) 0x9001);
-    f = getPhysicalAddress((void*) 0xA000);
+    // 获取映射后的物理地址
+    uint64_t* p = getPhysicalAddress((void*) 0x9000);
+    uint64_t* f = getPhysicalAddress((void*) 0xA000);
 
+    // 写入虚拟地址 0x9000，并读取
     uint64_t* y = (uint64_t*) 0x9000;
     *y = 0x114514;
     print_hex(*y, 0xFFFFFF); // 若分页运行正常，应该输出*y的值
     tty_print("\n", 0xFFFFFF);
+
     uint64_t* z = (uint64_t*) 0xA000;
-    print_hex(*z, 0xFFFFFF);
+    *z = 0x1919810;
+    print_hex(*z, 0xFFFFFF); // 若分页运行正常，应该输出*z的值
     tty_print("\n", 0xFFFFFF);
 
-
+    // 输出虚拟地址映射到的物理地址
     print_hex((uint64_t)p, 0xFFFFFF);
     tty_print("\n", 0xFFFFFF);
     print_hex((uint64_t)f, 0xFFFFFF);
     tty_print("\n", 0xFFFFFF);
+
+    // 释放分页映射
+    tty_print("\nReleasing paging...\n", 0xFF6347);
+    unmapPage((void*) 0x9000); // 释放虚拟地址 0x9000 的映射
+    unmapPage((void*) 0xA000); // 释放虚拟地址 0xA000 的映射
+
+    // 释放后再访问虚拟地址，检查是否出错
+    uint64_t* p_after_unmap = getPhysicalAddress((void*) 0x9000);
+    uint64_t* f_after_unmap = getPhysicalAddress((void*) 0xA000);
+
+    print_hex((uint64_t)p_after_unmap, 0xFF6347);
+    tty_print("\n", 0xFFFFFF);
+    print_hex((uint64_t)f_after_unmap, 0xFF6347);
+    tty_print("\n", 0xFFFFFF);
+
     tty_print("\nPaging test done.\n", 0x4EC9B0);
 
     print("[System ready.]\n", blue);

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -6,6 +6,7 @@
 #include "boot.h"
 #include "kernel/drivers/tty.h"
 #include "mem/pmm.h"
+#include "mem/paging.h"
 #include "command/shell.h"
 
 // ================== CPU/中断/定时器/PCI/驱动头文件 ==================
@@ -160,6 +161,10 @@ extern "C" void kmain(struct stivale_struct *stivale_struct) {
     print("Initializing Buddy...", white);
     buddy_init(boot_info);
     print("\nBuddy ready.\n", green);
+
+    print("Init paging...", white);
+    initPML4();
+    print("\nPaging initialized.\n", green);
 
     // 初始化 Keyboard
     print("Initializing Keyboard...", white);

--- a/kernel/mem/paging.cpp
+++ b/kernel/mem/paging.cpp
@@ -1,6 +1,11 @@
 #include "paging.h"
+#include "pmm.h"
 
 static PageTable* pml4;
+
+static inline void flushTLB(void* page) {
+	__asm__ volatile ("invlpg (%0)" :: "r" (page) : "memory");
+}
 
 uint64_t readCR3(void) {
     uint64_t val;
@@ -13,4 +18,72 @@ PageTable* initPML4() {
 	pml4 = (PageTable*) ((cr3 >> 12) << 12);
 
 	return pml4;
+}
+
+void setPageTableEntry(PageEntry* entry, uint8_t flags, uintptr_t physical_address, uint16_t available) {
+    entry->present = (flags >> 1) & 1;
+    entry->writable = (flags >> 2) & 1;
+    entry->user_accessible = (flags >> 3) & 1;
+    entry->write_through_caching = (flags & 0x8) & 1;
+    entry->disable_cache = (flags & 0x10) & 1;
+    entry->null = (flags & 0x20) & 1;
+    entry->global = (flags & 0x40) & 1;
+    entry->avl1 = available & 0x3;
+    entry->physical_address = physical_address; 
+    entry->avl2 = available >> 3;
+    entry->no_execute = flags >> 7;
+}
+
+size_t* getPhysicalAddress(void* virtual_address) 
+{
+    uintptr_t address = (uintptr_t) virtual_address;
+
+    uint64_t offset = address & 0xFFF;
+    uint64_t page_table_index = (address >> 12) & 0x1FF;
+    uint64_t page_directory_index = (address >> 21) & 0x1FF;
+    uint64_t page_directory_pointer_index = (address >> 30) & 0x1FF;
+    uint64_t pml4_index = (address >> 39) & 0x1FF;
+
+    PageTable* page_directory_pointer = (PageTable*) ((uint64_t) (pml4->entries[pml4_index].physical_address) << 12);
+    PageTable* page_directory = (PageTable*) ((uint64_t) (page_directory_pointer->entries[page_directory_pointer_index].physical_address) << 12);
+    PageTable* page_table = (PageTable*) ((uint64_t) (page_directory->entries[page_directory_index].physical_address) << 12);
+
+    return (size_t*) ((page_table->entries[page_table_index].physical_address << 12) + offset);
+}
+
+static void allocateEntry(PageTable* table, size_t index, uint8_t flags) {
+    void* physical_address = buddy_alloc(4096);
+    setPageTableEntry(&(table->entries[index]), flags, (uintptr_t) physical_address >> 12, 0);
+}
+
+
+void mapPage(void* virtual_address, void* physical_address, uint8_t flags) {
+    // Make sure that both addresses are page-aligned.
+    uintptr_t virtual_address_int = (uintptr_t) virtual_address;
+    uintptr_t physical_address_int = (uintptr_t) physical_address;
+
+    uint64_t pml4_index = (virtual_address_int >> 39) & 0x1FF;
+    uint64_t page_directory_pointer_index = (virtual_address_int >> 30) & 0x1FF;
+    uint64_t page_directory_index = (virtual_address_int >> 21) & 0x1FF;
+    uint64_t page_table_index = (virtual_address_int >> 12) & 0x1FF;
+ 
+    if (!pml4->entries[pml4_index].present)
+        allocateEntry(pml4, pml4_index, flags);
+
+    PageTable* page_directory_pointer = (PageTable*) (uint64_t) (pml4->entries[pml4_index].physical_address << 12);
+
+    if (!page_directory_pointer->entries[page_directory_pointer_index].present) 
+        allocateEntry(page_directory_pointer, page_directory_pointer_index, flags);
+
+    PageTable* page_directory = (PageTable*) (uint64_t) (page_directory_pointer->entries[page_directory_pointer_index].physical_address << 12);
+
+    if (!page_directory->entries[page_directory_index].present) 
+        allocateEntry(page_directory, page_directory_index, flags);
+
+    PageTable* page_table = (PageTable*) (uint64_t) (page_directory->entries[page_directory_index].physical_address << 12);
+
+    setPageTableEntry(&(page_table->entries[page_table_index]), flags, physical_address_int >> 12, 0);
+	
+    // Now you need to flush the entry in the TLB
+    flushTLB(virtual_address);
 }

--- a/kernel/mem/paging.cpp
+++ b/kernel/mem/paging.cpp
@@ -1,0 +1,16 @@
+#include "paging.h"
+
+static PageTable* pml4;
+
+uint64_t readCR3(void) {
+    uint64_t val;
+    __asm__ volatile ( "mov %%cr3, %0" : "=r"(val) );
+    return val;
+}
+
+PageTable* initPML4() {
+	uintptr_t cr3 = (uintptr_t) readCR3();
+	pml4 = (PageTable*) ((cr3 >> 12) << 12);
+
+	return pml4;
+}

--- a/kernel/mem/paging.h
+++ b/kernel/mem/paging.h
@@ -27,3 +27,5 @@ size_t* getPhysicalAddress(void* virtual_address);
 PageTable* initPML4(void); 
 void mapPage(void* virtual_address, void* physical_address, uint8_t flags);
 uint64_t readCR3(void);
+void unmapPage(void* virtual_address);
+bool anyPageTableEntryUsed(PageTable* table);

--- a/kernel/mem/paging.h
+++ b/kernel/mem/paging.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 struct PageEntry {
     uint8_t present : 1;
@@ -22,7 +23,7 @@ struct PageTable {
     PageEntry entries[512];
 } __attribute__((packed));
 
-//void* getPhysicalAddress(void* virtual_address); 
+size_t* getPhysicalAddress(void* virtual_address); 
 PageTable* initPML4(void); 
-//void mapPage(void* virtual_address, void* physical_address, uint8_t flags);
+void mapPage(void* virtual_address, void* physical_address, uint8_t flags);
 uint64_t readCR3(void);

--- a/kernel/mem/paging.h
+++ b/kernel/mem/paging.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdint.h>
+
+struct PageEntry {
+    uint8_t present : 1;
+    uint8_t writable : 1;
+    uint8_t user_accessible : 1;
+    uint8_t write_through_caching : 1;
+    uint8_t disable_cache : 1;
+    uint8_t accessed : 1;
+    uint8_t dirty : 1;
+    uint8_t null : 1;
+    uint8_t global : 1;
+    uint8_t avl1 : 3;
+    uintptr_t physical_address : 40;
+    uint16_t avl2 : 11;
+    uint8_t no_execute : 1;
+} __attribute__((packed));
+
+struct PageTable {
+    PageEntry entries[512];
+} __attribute__((packed));
+
+//void* getPhysicalAddress(void* virtual_address); 
+PageTable* initPML4(void); 
+//void mapPage(void* virtual_address, void* physical_address, uint8_t flags);
+uint64_t readCR3(void);


### PR DESCRIPTION
Implemented memory paging and basic virtual memory support in `kernel/mem/paging.cpp`, and tested the functionality in `kernel.cpp`.

This implementation is inspired by MakenOS (0BSD license): https://github.com/RickleAndMortimer/MakenOS and I improved it.